### PR TITLE
Fix XISF file headers incorrectly overriding filename-parsed values

### DIFF
--- a/ap_common/fits.py
+++ b/ap_common/fits.py
@@ -169,9 +169,12 @@ def get_xisf_headers(
     output = {}
 
     if file_naming_override:
+        # Don't normalize yet - use raw keys so the "if k in output" check
+        # correctly detects duplicate keys between filename and XISF headers.
+        # Normalization happens at the end after all headers are collected.
         output = get_file_headers(
             filename,
-            normalize=normalize,
+            normalize=False,
             profileFromPath=profileFromPath,
             directory_accept=directory_accept,
         )


### PR DESCRIPTION
When file_naming_override=True, filename headers were being normalized before checking for duplicate keys in XISF headers. This caused the "if k in output" check to fail (comparing raw 'EXPOSURE' to normalized 'exposureseconds'), allowing XISF header values to override filename values during final normalization.

The fix delays normalization of filename headers until the end, after all headers are collected. This ensures the duplicate key check works correctly and filename-parsed values take precedence as intended.

Fixes https://github.com/jewzaam/ap-common/issues/15

https://claude.ai/code/session_01ME27CJiMf6szLdskwFRE57