### PR TITLE
Fix file_naming_override not properly overriding FITS/XISF headers

### DIFF
--- a/ap_common/fits.py
+++ b/ap_common/fits.py
@@ -125,9 +125,12 @@ def get_fits_headers(
     output = {}
 
     if file_naming_override:
+        # Don't normalize yet - use raw keys so filename headers properly
+        # override FITS headers with the same raw keys during merge.
+        # Normalization happens at the end after all headers are collected.
         file_output = get_file_headers(
             filename,
-            normalize=normalize,
+            normalize=False,
             profileFromPath=profileFromPath,
             directory_accept=directory_accept,
         )


### PR DESCRIPTION
When file_naming_override=True and normalize=True, filename values were being overwritten by FITS/XISF header values during normalization because the keys were different (normalized vs raw). For example, a file named masterDark_EXPOSURE_100.00.xisf would show exposure as 300 (from XISF header) instead of 100 (from filename).

The fix ensures file headers are extracted without normalization first, so raw keys match and filename values properly override file header values. Normalization happens once at the end.

Fixes #15

https://claude.ai/code/session_01Jpe4kU88T3dztyJXeQEvDu