### PR TITLE
Add missing header constants for gain, offset, and focal length

### DIFF
--- a/ap_common/constants.py
+++ b/ap_common/constants.py
@@ -59,6 +59,13 @@ HEADER_OBSGEO_L = "OBSGEO-L"
 # Readout mode header
 HEADER_READOUTM = "READOUTM"
 
+# Camera settings headers
+HEADER_GAIN = "GAIN"
+HEADER_OFFSET = "OFFSET"
+
+# Focal length header
+HEADER_FOCALLEN = "FOCALLEN"
+
 # =============================================================================
 # Normalized Header Names
 # These are the standardized keys used internally after header normalization
@@ -78,6 +85,9 @@ NORMALIZED_HEADER_SETTEMP = "settemp"
 NORMALIZED_HEADER_LATITUDE = "latitude"
 NORMALIZED_HEADER_LONGITUDE = "longitude"
 NORMALIZED_HEADER_READOUTMODE = "readoutmode"
+NORMALIZED_HEADER_GAIN = "gain"
+NORMALIZED_HEADER_OFFSET = "offset"
+NORMALIZED_HEADER_FOCALLEN = "focallen"
 NORMALIZED_HEADER_PANEL = "panel"
 NORMALIZED_HEADER_FILENAME = "filename"
 NORMALIZED_HEADER_HFR = "hfr"


### PR DESCRIPTION
- Add HEADER_GAIN, HEADER_OFFSET, HEADER_FOCALLEN raw header constants
- Add NORMALIZED_HEADER_GAIN, NORMALIZED_HEADER_OFFSET, NORMALIZED_HEADER_FOCALLEN normalized constants
- Support camera settings and focal length metadata across projects

Assisted-by: Claude Code (Claude Sonnet 4.5)