### PR TITLE
Fix path normalization and FITS header conflict resolution

### DIFF
--- a/ap_common/normalization.py
+++ b/ap_common/normalization.py
@@ -276,6 +276,24 @@ def get_normalized_key(raw_key: str) -> str:
         return raw_key.lower()
 
 
+def get_all_normalized_keys(raw_key: str) -> list[str]:
+    """
+    Returns all normalized key names that a raw header key maps to.
+
+    For example, DATE-OBS maps to both 'date' and 'datetime'.
+
+    Args:
+        raw_key: The raw FITS header key
+
+    Returns:
+        List of all normalized keys this raw key produces, or [raw_key.lower()] if not in normalization data
+    """
+    if raw_key in FILTER_NORMALIZATION_DATA:
+        return list(FILTER_NORMALIZATION_DATA[raw_key].keys())
+    else:
+        return [raw_key.lower()]
+
+
 def get_normalized_keys_set(headers: dict) -> set:
     """
     Returns a set of normalized key names from a dictionary of raw headers.
@@ -290,7 +308,10 @@ def get_normalized_keys_set(headers: dict) -> set:
     Returns:
         Set of normalized key names
     """
-    return {get_normalized_key(k) for k in headers.keys()}
+    result = set()
+    for k in headers.keys():
+        result.update(get_all_normalized_keys(k))
+    return result
 
 
 def denormalize_header(header: str) -> str | None:

--- a/ap_common/utils.py
+++ b/ap_common/utils.py
@@ -147,10 +147,10 @@ def get_filenames(
     filenames = []
     for pattern in patterns:
         for dir in dirs:
-            resolved_dir = replace_env_vars(dir)
-            if resolved_dir is None:
+            # Normalize path separators to OS-appropriate format
+            dir = resolve_path(dir)
+            if dir is None:
                 continue
-            dir = resolved_dir
             if not recursive:
                 for filename in os.listdir(dir):
                     filename_path = os.path.join(dir, filename)
@@ -185,4 +185,7 @@ def get_filenames(
                         if "_stash" in root:
                             continue
                         filenames.append(os.path.join(root, filename))
+
+    # Normalize all output paths to OS-appropriate format
+    filenames = [resolve_path(f) for f in filenames]
     return filenames


### PR DESCRIPTION
- Normalize paths with resolve_path in get_file_headers, get_fits_headers, get_xisf_headers, and get_filenames
- Add get_all_normalized_keys to return all normalized keys for a raw header
- Update get_normalized_keys_set to include all normalized keys from multi-key headers
- Fix header conflict detection to only filter when ALL normalized keys overlap
- Add path normalization tests
- Add DATE-OBS preservation tests with file_naming_override

Assisted-by: Claude Code (Claude Sonnet 4.5)