### PR TITLE
Fix type errors in path normalization and enforce typecheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ lint: install-dev
 	$(PYTHON) -m flake8 --max-line-length=88 --extend-ignore=E203,W503,E501,F401 ap_common tests
 
 typecheck: install-dev
-	$(PYTHON) -m mypy ap_common || true
+	$(PYTHON) -m mypy ap_common
 
 test: install-dev
 	$(PYTHON) -m pytest

--- a/ap_common/fits.py
+++ b/ap_common/fits.py
@@ -36,7 +36,10 @@ def get_file_headers(
         directory_accept: The "accept" directory name to look for (project-specific, defaults to "accept")
     """
     # Normalize path separators to OS-appropriate format
-    filename = resolve_path(filename)
+    resolved = resolve_path(filename)
+    if resolved is None:
+        raise ValueError(f"Could not resolve path: {filename}")
+    filename = resolved
 
     directory_accept = directory_accept or "accept"
 
@@ -130,7 +133,10 @@ def get_fits_headers(
         directory_accept: The "accept" directory name (project-specific)
     """
     # Normalize path separators to OS-appropriate format
-    filename = resolve_path(filename)
+    resolved = resolve_path(filename)
+    if resolved is None:
+        raise ValueError(f"Could not resolve path: {filename}")
+    filename = resolved
 
     file_output = {}
     output = {}
@@ -201,7 +207,10 @@ def get_xisf_headers(
         directory_accept: The "accept" directory name (project-specific)
     """
     # Normalize path separators to OS-appropriate format
-    filename = resolve_path(filename)
+    resolved = resolve_path(filename)
+    if resolved is None:
+        raise ValueError(f"Could not resolve path: {filename}")
+    filename = resolved
 
     output = {}
 

--- a/ap_common/utils.py
+++ b/ap_common/utils.py
@@ -148,12 +148,12 @@ def get_filenames(
     for pattern in patterns:
         for dir in dirs:
             # Normalize path separators to OS-appropriate format
-            dir = resolve_path(dir)
-            if dir is None:
+            resolved_dir = resolve_path(dir)
+            if resolved_dir is None:
                 continue
             if not recursive:
-                for filename in os.listdir(dir):
-                    filename_path = os.path.join(dir, filename)
+                for filename in os.listdir(resolved_dir):
+                    filename_path = os.path.join(resolved_dir, filename)
                     # Check if it matches the pattern or is a zip file
                     if re.search(pattern, filename) or (
                         zips and zipfile.is_zipfile(filename_path)
@@ -177,7 +177,7 @@ def get_filenames(
                             # not a zip, simply add it
                             filenames.append(filename_path)
             else:
-                for root, _, f_names in os.walk(dir):
+                for root, _, f_names in os.walk(resolved_dir):
                     for filename in (
                         filename for filename in f_names if re.search(pattern, filename)
                     ):
@@ -187,5 +187,10 @@ def get_filenames(
                         filenames.append(os.path.join(root, filename))
 
     # Normalize all output paths to OS-appropriate format
-    filenames = [resolve_path(f) for f in filenames]
-    return filenames
+    # Filter out None values in case resolve_path fails
+    normalized_filenames = []
+    for f in filenames:
+        resolved = resolve_path(f)
+        if resolved is not None:
+            normalized_filenames.append(resolved)
+    return normalized_filenames


### PR DESCRIPTION
- Add None checks for resolve_path return values in fits.py
- Fix variable reassignment in get_filenames to use resolved_dir
- Filter out None values when normalizing output filenames
- Remove || true from typecheck Makefile target to enforce type checking

Assisted-by: Claude Code (Claude Sonnet 4.5)