### PR TITLE
Fix master calibration type constants for PixInsight inconsistency

### DIFF
--- a/ap_common/constants.py
+++ b/ap_common/constants.py
@@ -106,11 +106,13 @@ TYPE_BIAS = "BIAS"
 # =============================================================================
 # Image Type Constants - Master (Stacked) Frames
 # =============================================================================
+# Note: PixInsight inconsistency - BIAS and DARK don't get "MASTER" prefix,
+# but FLAT does. These constants match PixInsight's actual behavior.
 
 TYPE_MASTER_LIGHT = "MASTER LIGHT"
-TYPE_MASTER_DARK = "MASTER DARK"
+TYPE_MASTER_DARK = "DARK"
 TYPE_MASTER_FLAT = "MASTER FLAT"
-TYPE_MASTER_BIAS = "MASTER BIAS"
+TYPE_MASTER_BIAS = "BIAS"
 
 # =============================================================================
 # Calibration Frame Type Lists


### PR DESCRIPTION
- Update TYPE_MASTER_BIAS from "MASTER BIAS" to "BIAS"
- Update TYPE_MASTER_DARK from "MASTER DARK" to "DARK"
- Add comment documenting PixInsight's inconsistent IMAGETYP behavior

PixInsight does not prefix BIAS and DARK masters with "MASTER" in the IMAGETYP header, but does prefix FLAT masters with "MASTER FLAT".

Assisted-by: Claude Code (Claude Sonnet 4.5)