### PR TITLE
Add quiet mode support to logging configuration

### DIFF
--- a/ap_common/logging_config.py
+++ b/ap_common/logging_config.py
@@ -26,6 +26,7 @@ _logger = None
 def setup_logging(
     name: str = "ap_common",
     debug: bool = False,
+    quiet: bool = False,
     log_format: str = LOG_FORMAT,
     date_format: str = DATE_FORMAT,
 ):
@@ -37,20 +38,37 @@ def setup_logging(
 
     Args:
         name: Logger name (defaults to "ap_common")
-        debug: If True, sets log level to DEBUG; otherwise INFO
+        debug: If True, sets log level to DEBUG (overrides quiet)
+        quiet: If True, sets log level to WARNING (suppresses INFO)
         log_format: Custom log format string (defaults to LOG_FORMAT)
         date_format: Custom date format string (defaults to DATE_FORMAT)
 
     Returns:
         Configured logger instance
+
+    Logging Level Behavior:
+        | debug | quiet | Level   | Messages Shown           |
+        |-------|-------|---------|--------------------------|
+        | False | False | INFO    | INFO, WARNING, ERROR     |
+        | False | True  | WARNING | WARNING, ERROR           |
+        | True  | False | DEBUG   | DEBUG, INFO, WARNING, ERROR |
+        | True  | True  | DEBUG   | DEBUG, INFO, WARNING, ERROR |
+
+    Note: The debug flag overrides quiet mode. When debug=True, all messages
+    are shown regardless of the quiet setting.
     """
     logger = logging.getLogger(name)
 
     # Clear existing handlers to prevent duplicates
     logger.handlers.clear()
 
-    # Set log level based on debug flag
-    level = logging.DEBUG if debug else logging.INFO
+    # Set log level based on flags
+    if debug:
+        level = logging.DEBUG  # Debug overrides quiet
+    elif quiet:
+        level = logging.WARNING  # Quiet suppresses INFO
+    else:
+        level = logging.INFO  # Default
     logger.setLevel(level)
 
     # Create console handler

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -86,6 +86,45 @@ class TestSetupLogging:
         assert formatter._fmt == LOG_FORMAT
         assert formatter.datefmt == DATE_FORMAT
 
+    def test_quiet_level_true(self):
+        """Test log level is WARNING when quiet=True."""
+        logger = setup_logging(name="test_logger_quiet_1", quiet=True)
+        assert logger.level == logging.WARNING
+
+    def test_debug_overrides_quiet(self):
+        """Test debug=True overrides quiet=True to DEBUG level."""
+        logger = setup_logging(name="test_logger_quiet_2", debug=True, quiet=True)
+        assert logger.level == logging.DEBUG
+
+    def test_default_quiet_is_false(self):
+        """Test quiet defaults to False (INFO level)."""
+        logger = setup_logging(name="test_logger_quiet_3")
+        assert logger.level == logging.INFO
+
+    def test_handler_level_matches_quiet(self):
+        """Test handler level matches WARNING when quiet=True."""
+        logger = setup_logging(name="test_logger_quiet_4", quiet=True)
+        assert logger.handlers[0].level == logging.WARNING
+
+    def test_quiet_mode_suppresses_info(self):
+        """Test INFO messages are filtered in quiet mode."""
+        logger = setup_logging(name="test_logger_quiet_5", quiet=True)
+
+        stream = StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setLevel(logging.WARNING)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.handlers = [handler]
+
+        logger.info("Info message")
+        logger.warning("Warning message")
+        logger.error("Error message")
+
+        output = stream.getvalue()
+        assert "Info message" not in output
+        assert "Warning message" in output
+        assert "Error message" in output
+
 
 class TestGetLogger:
     """Tests for get_logger function."""


### PR DESCRIPTION
Implement quiet parameter in setup_logging() to enable WARNING-level logging that suppresses INFO messages. Debug flag overrides quiet mode.

Changes:
- Add quiet parameter to setup_logging() (defaults to False for backward compatibility)
- Update log level logic: DEBUG if debug=True, WARNING if quiet=True, otherwise INFO
- Add comprehensive test coverage (5 new tests for quiet mode behavior)
- Update docstring with behavior table and parameter descriptions

Test coverage: 100% for logging_config.py (all 24 tests pass)

This fulfills CLI standards requirement that all tools support --quiet flag.

Addresses ap-base plan: Quiet Mode Support for ap-common Logging (Phase 1)

Assisted-by: Claude Code (Claude Sonnet 4.5)