### PR TITLE
Remove target name from enriching metadata progress indicator

### DIFF
--- a/ap_common/metadata.py
+++ b/ap_common/metadata.py
@@ -173,10 +173,6 @@ def enrich_metadata(
             # Build profile and add to enriched data
             enriched["profile"] = build_profile(enriched)
 
-            # Update progress bar status with current target if available
-            if "targetname" in enriched and enriched["targetname"]:
-                tracker.set_status(enriched["targetname"])
-
             # store the now-enriched data
             data[filename] = enriched
 


### PR DESCRIPTION
- Remove set_status call showing target name during metadata enrichment
- Ensures consistent progress indicator output across all operations

Assisted-by: Claude Code (claude-sonnet-4-5-20250929)