### PR TITLE
Fix DATE-OBS header parsing in filenames

### DIFF
--- a/ap_common/fits.py
+++ b/ap_common/fits.py
@@ -13,11 +13,11 @@ from typing import Any, Dict, Optional
 from astropy.io import fits
 from ap_common.normalization import (
     normalize_headers,
-    get_normalized_key,
     get_normalized_keys_set,
     get_all_normalized_keys,
+    FILTER_NORMALIZATION_DATA,
 )
-from ap_common.utils import replace_env_vars, resolve_path
+from ap_common.utils import resolve_path
 
 logger = logging.getLogger(__name__)
 
@@ -95,6 +95,11 @@ def get_file_headers(
                 output[k] = v
         for x in m1:
             if "-" in x:
+                # Skip hyphen-splitting for known FITS header keywords
+                # (e.g., DATE-OBS, SET-TEMP, CCD-TEMP, OBSGEO-B, OBSGEO-L)
+                # These use hyphens as part of the key name, not as separators
+                if x.upper() in FILTER_NORMALIZATION_DATA:
+                    continue
                 m2 = re.split("[-]", x)
                 k = m2[0]
                 v = "-".join(m2[1:])

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -113,6 +113,28 @@ class TestGetFileHeaders:
         # Should have normalized keys
         assert "filter" in result or "exposureseconds" in result
 
+    def test_date_obs_in_filename_normalized_correctly(self):
+        """Test that DATE-OBS in filename results in correct date after normalization.
+
+        Regression test for bug where "DATE-OBS_2026-01-15" in filename
+        would incorrectly set date="OBS" instead of date="2026-01-15".
+
+        The bug occurred because:
+        1. Underscore parsing extracted: DATE-OBS → 2026-01-15
+        2. Hyphen parsing then split DATE-OBS into: DATE → OBS
+        3. After normalization, the "date" key ended up with "OBS"
+        """
+        from ap_common.constants import NORMALIZED_HEADER_DATE
+
+        # This is the pattern from the bug report in ap-move-master-to-library
+        filename = "masterFlat_FILTER_B_DATE-OBS_2026-01-15_SETTEMP_-10.00.fits"
+        result = get_file_headers(filename, profileFromPath=False, normalize=True)
+
+        # The date should be correctly extracted from DATE-OBS, not incorrectly set to "OBS"
+        assert NORMALIZED_HEADER_DATE in result
+        assert result[NORMALIZED_HEADER_DATE] == "2026-01-15"
+        assert result[NORMALIZED_HEADER_DATE] != "OBS"
+
 
 class TestGetFitsHeaders:
     """Tests for get_fits_headers function."""


### PR DESCRIPTION
- Skip hyphen-splitting for known FITS header keywords in get_file_headers
- Prevent DATE-OBS from being incorrectly split into DATE=OBS
- Add regression test for DATE-OBS filename parsing

Assisted-by: Claude Code (Claude Sonnet 4.5)