### PR TITLE
Normalize None header values to empty string for strict matching

### DIFF
--- a/ap_common/normalization.py
+++ b/ap_common/normalization.py
@@ -216,11 +216,13 @@ def normalize_headers(
     output: dict[str, str] = {}
     for key in input.keys():
         value = input[key]
-        if value is not None and key in FILTER_NORMALIZATION_DATA.keys():
+        if key in FILTER_NORMALIZATION_DATA.keys():
             norm_data = FILTER_NORMALIZATION_DATA[key]
             for normalized_keyword in norm_data:
+                if value is None:
+                    output[normalized_keyword] = ""
                 # For date/datetime normalization, pass timezone if provided
-                if key == "DATE-OBS" and normalized_keyword in ["date", "datetime"]:
+                elif key == "DATE-OBS" and normalized_keyword in ["date", "datetime"]:
                     if normalized_keyword == "date":
                         output[normalized_keyword] = normalize_date(
                             value, timezone_offset_from_gmt=timezone_offset_from_gmt
@@ -233,8 +235,8 @@ def normalize_headers(
                     conversion_function = norm_data[normalized_keyword]
                     output[normalized_keyword] = conversion_function(value)
         else:
-            # simply convert to lower case
-            output[key.lower()] = value
+            # simply convert to lower case, normalize None to empty string
+            output[key.lower()] = "" if value is None else value
     # final special case, strip panel out of target name
     if "panel" not in output and "targetname" in output and output["targetname"]:
         x = normalize_target_name(output["targetname"])
@@ -250,6 +252,14 @@ def normalize_headers(
                     cvalue = const_values[ckey]
                     if ckey not in output:
                         output[ckey] = cvalue
+
+    # Normalize None values to empty string for consistent strict matching
+    # This ensures all downstream code (grouping, matching, filtering) gets
+    # clean data without needing to handle None separately
+    for key in output.keys():
+        if output[key] is None:
+            output[key] = ""
+
     return output
 
 

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -277,6 +277,69 @@ class TestNormalizeHeaders:
         assert result["optic"] == "Refractor"
         assert result["camera"] == "Camera1"
 
+    def test_none_values_normalized_to_empty_string(self):
+        """Test that None values are normalized to empty string."""
+        headers = {
+            "FILTER": None,  # None value
+            "EXPOSURE": "60.0",
+            "INSTRUME": None,  # None value
+        }
+        result = normalize_headers(headers)
+        # None values should be converted to empty string
+        assert result["filter"] == ""
+        assert result["camera"] == ""
+        # Non-None values should be preserved
+        assert result["exposureseconds"] == "60.00"
+
+    def test_none_in_unknown_headers_normalized(self):
+        """Test that None values in unknown headers are normalized to empty string."""
+        headers = {
+            "UNKNOWN_HEADER": None,  # Unknown header with None value
+            "ANOTHER_HEADER": "value",
+        }
+        result = normalize_headers(headers)
+        # None value should be converted to empty string even for unknown headers
+        assert result["unknown_header"] == ""
+        assert result["another_header"] == "value"
+
+    def test_multiple_none_values_normalized(self):
+        """Test that multiple None values are all normalized to empty string."""
+        headers = {
+            "FILTER": None,
+            "GAIN": None,
+            "OFFSET": None,
+            "EXPOSURE": "120.0",
+        }
+        result = normalize_headers(headers)
+        # All None values should be empty strings
+        assert result["filter"] == ""
+        assert result["gain"] == ""
+        assert result["offset"] == ""
+        # Non-None values preserved
+        assert result["exposureseconds"] == "120.00"
+
+    def test_none_normalization_for_strict_matching(self):
+        """Test that None normalization enables strict matching behavior.
+
+        This verifies the fix for inconsistent None/empty filter handling where:
+        - Before: None values caused permissive matching or were removed from criteria
+        - After: None values normalized to "" for consistent strict matching
+        """
+        headers = {
+            "FILTER": None,  # Light with no filter
+            "INSTRUME": "ASI2600MM",
+            "EXPOSURE": "300.0",
+        }
+        result = normalize_headers(headers)
+
+        # After normalization, filter should be empty string (not None)
+        assert "filter" in result
+        assert result["filter"] == ""
+        assert result["filter"] is not None
+
+        # This enables strict matching: filter="" only matches filter=""
+        # (not wildcarding to match filter="Ha", filter="OIII", etc.)
+
 
 class TestDenormalizeHeader:
     """Tests for denormalize_header function."""


### PR DESCRIPTION
- Apply key mapping (INSTRUME→camera) even when value is None
- Convert None values to empty string immediately for type safety
- Normalize unknown header None values to empty string
- Add final None-to-empty-string pass for consistent strict matching

Assisted-by: Claude Code (Claude Sonnet 4.5)