### PR TITLE
Refactor calibration matching to support cache-based operation

### DIFF
--- a/ap_common/__init__.py
+++ b/ap_common/__init__.py
@@ -37,6 +37,9 @@ from ap_common.calibration import (
     find_matching_darks,
     find_matching_flats,
     find_matching_bias,
+    find_matching_darks_from_cache,
+    find_matching_flats_from_cache,
+    find_matching_bias_from_cache,
 )
 from ap_common.constants import (
     # Directory constants
@@ -101,6 +104,7 @@ from ap_common.constants import (
     DEFAULT_FITS_PATTERN,
     DEFAULT_XISF_PATTERN,
     DEFAULT_CR2_PATTERN,
+    DEFAULT_IMAGE_PATTERNS,
     DEFAULT_CALIBRATION_PATTERNS,
 )
 
@@ -145,6 +149,9 @@ __all__ = [
     "find_matching_darks",
     "find_matching_flats",
     "find_matching_bias",
+    "find_matching_darks_from_cache",
+    "find_matching_flats_from_cache",
+    "find_matching_bias_from_cache",
     # Directory constants
     "DIRECTORY_ACCEPT",
     # FITS Header constants
@@ -207,5 +214,6 @@ __all__ = [
     "DEFAULT_FITS_PATTERN",
     "DEFAULT_XISF_PATTERN",
     "DEFAULT_CR2_PATTERN",
+    "DEFAULT_IMAGE_PATTERNS",
     "DEFAULT_CALIBRATION_PATTERNS",
 ]

--- a/ap_common/calibration.py
+++ b/ap_common/calibration.py
@@ -11,7 +11,11 @@ from typing import Dict, List, Union, Optional
 from pathlib import Path
 import logging
 
-from ap_common.metadata import get_filtered_metadata, build_normalized_filters
+from ap_common.metadata import (
+    get_metadata,
+    get_filtered_metadata,
+    build_normalized_filters,
+)
 from ap_common.constants import (
     TYPE_MASTER_DARK,
     TYPE_MASTER_FLAT,
@@ -65,71 +69,33 @@ def find_matching_darks(
         # Returns all matching darks from /blink and subdirectories
         # Paths in results show where each dark is located
     """
-    # Get light exposure for comparison
-    light_exposure = float(reference.get(NORMALIZED_HEADER_EXPOSURESECONDS, -1))
-
-    # Build filter criteria (without exposure initially)
-    # Different cameras have different metadata (DSLRs: ISO not gain, no offset/readoutmode)
-    filter_criteria = build_normalized_filters(
-        reference,
-        match_fields,
-        overrides={NORMALIZED_HEADER_TYPE: TYPE_MASTER_DARK},
-    )
-
-    logger.debug(f"Searching for darks with criteria: {filter_criteria}")
-    logger.debug(f"Target exposure: {light_exposure}s")
-
-    # Search for all matching darks (any exposure)
+    # Load metadata from disk
     if patterns is None:
         patterns = DEFAULT_CALIBRATION_PATTERNS
 
     # IMPORTANT: profileFromPath only works with blink/data directory structure
     # For library searches, it should typically be False to read actual file headers
-    darks = get_filtered_metadata(
+    metadata_dict = get_metadata(
         dirs=[str(search_dir)],
-        filters=filter_criteria,
-        profileFromPath=profileFromPath,
         patterns=patterns,
         recursive=recursive,
+        profileFromPath=profileFromPath,
         printStatus=printStatus,
     )
 
-    if not darks:
+    if not metadata_dict:
         logger.debug(
-            f"No darks found matching criteria in {search_dir} (recursive={recursive}, patterns={patterns})"
+            f"No files found in {search_dir} (recursive={recursive}, patterns={patterns})"
         )
         return []
 
-    logger.debug(f"Found {len(darks)} darks matching criteria")
-
-    # Convert dict to list of metadata dicts
-    darks_list = list(darks.values())
-
-    # Filter by exposure logic
-    matching = []
-    for dark_meta in darks_list:
-        dark_exposure = float(dark_meta.get(NORMALIZED_HEADER_EXPOSURESECONDS, -1))
-
-        # Accept if exact match
-        if dark_exposure == light_exposure:
-            matching.append(dark_meta)
-        # Or if shorter exposure allowed
-        elif allow_shorter_exposure and dark_exposure < light_exposure:
-            matching.append(dark_meta)
-
-    available_exposures = sorted(
-        [float(d.get(NORMALIZED_HEADER_EXPOSURESECONDS, -1)) for d in darks_list]
+    # Delegate to cache-based function
+    return find_matching_darks_from_cache(
+        metadata_dict=metadata_dict,
+        reference=reference,
+        match_fields=match_fields,
+        allow_shorter_exposure=allow_shorter_exposure,
     )
-    logger.debug(f"Available dark exposures: {available_exposures}")
-    logger.debug(f"After exposure filtering: {len(matching)} matching darks")
-
-    # Sort by exposure (longest first)
-    matching.sort(
-        key=lambda d: float(d.get(NORMALIZED_HEADER_EXPOSURESECONDS, -1)),
-        reverse=True,
-    )
-
-    return matching
 
 
 def find_matching_flats(
@@ -175,33 +141,30 @@ def find_matching_flats(
             recursive=False  # Just this directory
         )
     """
-    # Build filter criteria
-    # Different cameras have different metadata (DSLRs: ISO not gain, no offset/readoutmode)
-    filter_criteria = build_normalized_filters(
-        reference,
-        match_fields,
-        overrides={NORMALIZED_HEADER_TYPE: TYPE_MASTER_FLAT},
-    )
-
-    logger.debug(f"Searching for flats with criteria: {filter_criteria}")
-
-    # Search for matching flats
+    # Load metadata from disk
     if patterns is None:
         patterns = DEFAULT_CALIBRATION_PATTERNS
 
-    flats = get_filtered_metadata(
+    metadata_dict = get_metadata(
         dirs=[str(search_dir)],
-        filters=filter_criteria,
-        profileFromPath=profileFromPath,
         patterns=patterns,
         recursive=recursive,
+        profileFromPath=profileFromPath,
         printStatus=printStatus,
     )
 
-    logger.debug(f"Found {len(flats)} matching flats")
+    if not metadata_dict:
+        logger.debug(
+            f"No files found in {search_dir} (recursive={recursive}, patterns={patterns})"
+        )
+        return []
 
-    # Convert dict to list of metadata dicts
-    return list(flats.values())
+    # Delegate to cache-based function
+    return find_matching_flats_from_cache(
+        metadata_dict=metadata_dict,
+        reference=reference,
+        match_fields=match_fields,
+    )
 
 
 def find_matching_bias(
@@ -239,30 +202,227 @@ def find_matching_bias(
             recursive=True
         )
     """
+    # Load metadata from disk
+    if patterns is None:
+        patterns = DEFAULT_CALIBRATION_PATTERNS
+
+    metadata_dict = get_metadata(
+        dirs=[str(search_dir)],
+        patterns=patterns,
+        recursive=recursive,
+        profileFromPath=profileFromPath,
+        printStatus=printStatus,
+    )
+
+    if not metadata_dict:
+        logger.debug(
+            f"No files found in {search_dir} (recursive={recursive}, patterns={patterns})"
+        )
+        return []
+
+    # Delegate to cache-based function
+    return find_matching_bias_from_cache(
+        metadata_dict=metadata_dict,
+        reference=reference,
+        match_fields=match_fields,
+    )
+
+
+# =============================================================================
+# Cache-based calibration matching functions
+# =============================================================================
+
+
+def find_matching_darks_from_cache(
+    metadata_dict: Dict[str, Dict[str, str]],
+    reference: Dict[str, str],
+    match_fields: List[str],
+    allow_shorter_exposure: bool = False,
+) -> List[Dict[str, str]]:
+    """
+    Find dark frames matching reference metadata from a pre-loaded metadata dict.
+
+    This function searches within a pre-loaded metadata cache instead of loading
+    from disk, making it suitable for scenarios where metadata has been loaded
+    once upfront to avoid redundant I/O.
+
+    Args:
+        metadata_dict: Pre-loaded metadata dictionary mapping filename to metadata
+        reference: Light frame metadata to match against
+        match_fields: List of metadata fields that must match exactly
+        allow_shorter_exposure: If True, accept darks with exposure < light exposure
+                                If False, only accept exact exposure match
+
+    Returns:
+        List of metadata dicts for matching darks, sorted by exposure (longest first)
+        Each dict includes NORMALIZED_HEADER_FILENAME for the file path
+
+    Example:
+        # Load all metadata once
+        metadata = get_metadata(dirs=["/blink"], recursive=True)
+
+        # Find matching darks from cache
+        from ap_common.constants import CAMERA, GAIN, OFFSET, SETTEMP, READOUTMODE
+        darks = find_matching_darks_from_cache(
+            metadata,
+            light_meta,
+            match_fields=[CAMERA, GAIN, OFFSET, SETTEMP, READOUTMODE],
+            allow_shorter_exposure=True
+        )
+    """
+    # Get light exposure for comparison
+    light_exposure = float(reference.get(NORMALIZED_HEADER_EXPOSURESECONDS, -1))
+
     # Build filter criteria
-    # Different cameras have different metadata (DSLRs: ISO not gain, no offset/readoutmode)
+    filter_criteria = build_normalized_filters(
+        reference,
+        match_fields,
+        overrides={NORMALIZED_HEADER_TYPE: TYPE_MASTER_DARK},
+    )
+
+    logger.debug(f"Searching for darks in cache with criteria: {filter_criteria}")
+    logger.debug(f"Target exposure: {light_exposure}s")
+
+    # Filter from provided metadata dict
+    darks = {}
+    for filename, metadata in metadata_dict.items():
+        # Check if metadata matches all filter criteria
+        if all(metadata.get(k) == v for k, v in filter_criteria.items()):
+            darks[filename] = metadata
+
+    logger.debug(f"Found {len(darks)} darks matching criteria in cache")
+
+    # Convert to list
+    darks_list = list(darks.values())
+
+    # Filter by exposure logic
+    matching = []
+    for dark_meta in darks_list:
+        dark_exposure = float(dark_meta.get(NORMALIZED_HEADER_EXPOSURESECONDS, -1))
+
+        # Accept if exact match
+        if dark_exposure == light_exposure:
+            matching.append(dark_meta)
+        # Or if shorter exposure allowed
+        elif allow_shorter_exposure and dark_exposure < light_exposure:
+            matching.append(dark_meta)
+
+    logger.debug(f"After exposure filtering: {len(matching)} matching darks")
+
+    # Sort by exposure (longest first)
+    matching.sort(
+        key=lambda d: float(d.get(NORMALIZED_HEADER_EXPOSURESECONDS, -1)),
+        reverse=True,
+    )
+
+    return matching
+
+
+def find_matching_flats_from_cache(
+    metadata_dict: Dict[str, Dict[str, str]],
+    reference: Dict[str, str],
+    match_fields: List[str],
+) -> List[Dict[str, str]]:
+    """
+    Find flat frames matching reference metadata from a pre-loaded metadata dict.
+
+    This function searches within a pre-loaded metadata cache instead of loading
+    from disk, making it suitable for scenarios where metadata has been loaded
+    once upfront to avoid redundant I/O.
+
+    Args:
+        metadata_dict: Pre-loaded metadata dictionary mapping filename to metadata
+        reference: Light frame metadata to match against
+        match_fields: List of metadata fields that must match exactly
+
+    Returns:
+        List of metadata dicts for matching flats
+        Each dict includes NORMALIZED_HEADER_FILENAME for the file path
+
+    Example:
+        # Load all metadata once
+        metadata = get_metadata(dirs=["/blink"], recursive=True)
+
+        # Find matching flats from cache
+        from ap_common.constants import CAMERA, FILTER, GAIN, OFFSET
+        flats = find_matching_flats_from_cache(
+            metadata,
+            light_meta,
+            match_fields=[CAMERA, FILTER, GAIN, OFFSET]
+        )
+    """
+    # Build filter criteria
+    filter_criteria = build_normalized_filters(
+        reference,
+        match_fields,
+        overrides={NORMALIZED_HEADER_TYPE: TYPE_MASTER_FLAT},
+    )
+
+    logger.debug(f"Searching for flats in cache with criteria: {filter_criteria}")
+
+    # Filter from provided metadata dict
+    flats = {}
+    for filename, metadata in metadata_dict.items():
+        # Check if metadata matches all filter criteria
+        if all(metadata.get(k) == v for k, v in filter_criteria.items()):
+            flats[filename] = metadata
+
+    logger.debug(f"Found {len(flats)} matching flats in cache")
+
+    # Convert dict to list of metadata dicts
+    return list(flats.values())
+
+
+def find_matching_bias_from_cache(
+    metadata_dict: Dict[str, Dict[str, str]],
+    reference: Dict[str, str],
+    match_fields: List[str],
+) -> List[Dict[str, str]]:
+    """
+    Find bias frames matching reference metadata from a pre-loaded metadata dict.
+
+    This function searches within a pre-loaded metadata cache instead of loading
+    from disk, making it suitable for scenarios where metadata has been loaded
+    once upfront to avoid redundant I/O.
+
+    Args:
+        metadata_dict: Pre-loaded metadata dictionary mapping filename to metadata
+        reference: Light frame metadata to match against
+        match_fields: List of metadata fields that must match exactly
+
+    Returns:
+        List of metadata dicts for matching bias frames
+        Each dict includes NORMALIZED_HEADER_FILENAME for the file path
+
+    Example:
+        # Load all metadata once
+        metadata = get_metadata(dirs=["/library"], recursive=True)
+
+        # Find matching bias from cache
+        from ap_common.constants import CAMERA, GAIN, OFFSET, SETTEMP, READOUTMODE
+        bias_frames = find_matching_bias_from_cache(
+            metadata,
+            light_meta,
+            match_fields=[CAMERA, GAIN, OFFSET, SETTEMP, READOUTMODE]
+        )
+    """
+    # Build filter criteria
     filter_criteria = build_normalized_filters(
         reference,
         match_fields,
         overrides={NORMALIZED_HEADER_TYPE: TYPE_MASTER_BIAS},
     )
 
-    logger.debug(f"Searching for bias with criteria: {filter_criteria}")
+    logger.debug(f"Searching for bias in cache with criteria: {filter_criteria}")
 
-    # Search for matching bias
-    if patterns is None:
-        patterns = DEFAULT_CALIBRATION_PATTERNS
+    # Filter from provided metadata dict
+    bias = {}
+    for filename, metadata in metadata_dict.items():
+        # Check if metadata matches all filter criteria
+        if all(metadata.get(k) == v for k, v in filter_criteria.items()):
+            bias[filename] = metadata
 
-    bias = get_filtered_metadata(
-        dirs=[str(search_dir)],
-        filters=filter_criteria,
-        profileFromPath=profileFromPath,
-        patterns=patterns,
-        recursive=recursive,
-        printStatus=printStatus,
-    )
-
-    logger.debug(f"Found {len(bias)} matching bias frames")
+    logger.debug(f"Found {len(bias)} matching bias frames in cache")
 
     # Convert dict to list of metadata dicts
     return list(bias.values())

--- a/ap_common/constants.py
+++ b/ap_common/constants.py
@@ -140,5 +140,11 @@ FILE_EXTENSION_CR2 = ".cr2"
 DEFAULT_FITS_PATTERN = r".*\.fits$"
 DEFAULT_XISF_PATTERN = r".*\.xisf$"
 DEFAULT_CR2_PATTERN = r".*\.cr2$"
+# All supported image types (light frames and calibration)
+DEFAULT_IMAGE_PATTERNS = [
+    DEFAULT_FITS_PATTERN,
+    DEFAULT_XISF_PATTERN,
+    DEFAULT_CR2_PATTERN,
+]
 # Master calibration frames (never CR2)
 DEFAULT_CALIBRATION_PATTERNS = [DEFAULT_FITS_PATTERN, DEFAULT_XISF_PATTERN]

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -10,6 +10,9 @@ from ap_common.calibration import (
     find_matching_darks,
     find_matching_flats,
     find_matching_bias,
+    find_matching_darks_from_cache,
+    find_matching_flats_from_cache,
+    find_matching_bias_from_cache,
 )
 from ap_common.constants import (
     NORMALIZED_HEADER_TYPE,
@@ -30,19 +33,23 @@ from ap_common.constants import (
 class TestFindMatchingDarks:
     """Tests for find_matching_darks function."""
 
-    @patch("ap_common.calibration.get_filtered_metadata")
-    def test_exact_exposure_match(self, mock_get_filtered):
+    @patch("ap_common.calibration.get_metadata")
+    def test_exact_exposure_match(self, mock_get_metadata):
         """Test finding darks with exact exposure match."""
         # Setup mock
-        mock_get_filtered.return_value = {
+        mock_get_metadata.return_value = {
             "/path/dark1.fits": {
                 NORMALIZED_HEADER_FILENAME: "/path/dark1.fits",
+                NORMALIZED_HEADER_TYPE: TYPE_MASTER_DARK,
                 NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
+                NORMALIZED_HEADER_GAIN: "100",
                 NORMALIZED_HEADER_CAMERA: "ASI2600MM",
             },
             "/path/dark2.fits": {
                 NORMALIZED_HEADER_FILENAME: "/path/dark2.fits",
+                NORMALIZED_HEADER_TYPE: TYPE_MASTER_DARK,
                 NORMALIZED_HEADER_EXPOSURESECONDS: "120.0",
+                NORMALIZED_HEADER_GAIN: "100",
                 NORMALIZED_HEADER_CAMERA: "ASI2600MM",
             },
         }
@@ -65,19 +72,23 @@ class TestFindMatchingDarks:
         assert result[0][NORMALIZED_HEADER_EXPOSURESECONDS] == "60.0"
         assert result[0][NORMALIZED_HEADER_FILENAME] == "/path/dark1.fits"
 
-    @patch("ap_common.calibration.get_filtered_metadata")
-    def test_shorter_exposure_allowed(self, mock_get_filtered):
+    @patch("ap_common.calibration.get_metadata")
+    def test_shorter_exposure_allowed(self, mock_get_metadata):
         """Test finding darks with shorter exposure when allowed."""
         # Setup mock
-        mock_get_filtered.return_value = {
+        mock_get_metadata.return_value = {
             "/path/dark1.fits": {
                 NORMALIZED_HEADER_FILENAME: "/path/dark1.fits",
+                NORMALIZED_HEADER_TYPE: TYPE_MASTER_DARK,
                 NORMALIZED_HEADER_EXPOSURESECONDS: "30.0",
+                NORMALIZED_HEADER_GAIN: "100",
                 NORMALIZED_HEADER_CAMERA: "ASI2600MM",
             },
             "/path/dark2.fits": {
                 NORMALIZED_HEADER_FILENAME: "/path/dark2.fits",
+                NORMALIZED_HEADER_TYPE: TYPE_MASTER_DARK,
                 NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
+                NORMALIZED_HEADER_GAIN: "100",
                 NORMALIZED_HEADER_CAMERA: "ASI2600MM",
             },
         }
@@ -101,14 +112,16 @@ class TestFindMatchingDarks:
         assert result[0][NORMALIZED_HEADER_EXPOSURESECONDS] == "60.0"
         assert result[1][NORMALIZED_HEADER_EXPOSURESECONDS] == "30.0"
 
-    @patch("ap_common.calibration.get_filtered_metadata")
-    def test_shorter_exposure_not_allowed(self, mock_get_filtered):
+    @patch("ap_common.calibration.get_metadata")
+    def test_shorter_exposure_not_allowed(self, mock_get_metadata):
         """Test rejecting shorter exposure darks when not allowed."""
         # Setup mock
-        mock_get_filtered.return_value = {
+        mock_get_metadata.return_value = {
             "/path/dark1.fits": {
                 NORMALIZED_HEADER_FILENAME: "/path/dark1.fits",
+                NORMALIZED_HEADER_TYPE: TYPE_MASTER_DARK,
                 NORMALIZED_HEADER_EXPOSURESECONDS: "30.0",
+                NORMALIZED_HEADER_GAIN: "100",
                 NORMALIZED_HEADER_CAMERA: "ASI2600MM",
             },
         }
@@ -130,10 +143,10 @@ class TestFindMatchingDarks:
         # Should reject shorter dark when not allowed
         assert len(result) == 0
 
-    @patch("ap_common.calibration.get_filtered_metadata")
-    def test_no_matches(self, mock_get_filtered):
+    @patch("ap_common.calibration.get_metadata")
+    def test_no_matches(self, mock_get_metadata):
         """Test when no darks match."""
-        mock_get_filtered.return_value = {}
+        mock_get_metadata.return_value = {}
 
         reference = {
             NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
@@ -150,14 +163,16 @@ class TestFindMatchingDarks:
 
         assert len(result) == 0
 
-    @patch("ap_common.calibration.get_filtered_metadata")
-    def test_longer_exposure_rejected(self, mock_get_filtered):
+    @patch("ap_common.calibration.get_metadata")
+    def test_longer_exposure_rejected(self, mock_get_metadata):
         """Test that longer exposure darks are rejected."""
         # Setup mock
-        mock_get_filtered.return_value = {
+        mock_get_metadata.return_value = {
             "/path/dark1.fits": {
                 NORMALIZED_HEADER_FILENAME: "/path/dark1.fits",
+                NORMALIZED_HEADER_TYPE: TYPE_MASTER_DARK,
                 NORMALIZED_HEADER_EXPOSURESECONDS: "180.0",
+                NORMALIZED_HEADER_GAIN: "100",
                 NORMALIZED_HEADER_CAMERA: "ASI2600MM",
             },
         }
@@ -179,10 +194,10 @@ class TestFindMatchingDarks:
         # Longer exposure dark should always be rejected
         assert len(result) == 0
 
-    @patch("ap_common.calibration.get_filtered_metadata")
-    def test_recursive_vs_nonrecursive(self, mock_get_filtered):
+    @patch("ap_common.calibration.get_metadata")
+    def test_recursive_vs_nonrecursive(self, mock_get_metadata):
         """Test that recursive parameter is passed correctly."""
-        mock_get_filtered.return_value = {}
+        mock_get_metadata.return_value = {}
 
         reference = {
             NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
@@ -199,7 +214,7 @@ class TestFindMatchingDarks:
         )
 
         # Check that get_filtered_metadata was called with recursive=True
-        call_args = mock_get_filtered.call_args
+        call_args = mock_get_metadata.call_args
         assert call_args[1]["recursive"] is True
 
         # Test recursive=False
@@ -212,21 +227,23 @@ class TestFindMatchingDarks:
         )
 
         # Check that get_filtered_metadata was called with recursive=False
-        call_args = mock_get_filtered.call_args
+        call_args = mock_get_metadata.call_args
         assert call_args[1]["recursive"] is False
 
 
 class TestFindMatchingFlats:
     """Tests for find_matching_flats function."""
 
-    @patch("ap_common.calibration.get_filtered_metadata")
-    def test_basic_flat_matching(self, mock_get_filtered):
+    @patch("ap_common.calibration.get_metadata")
+    def test_basic_flat_matching(self, mock_get_metadata):
         """Test basic flat matching."""
-        mock_get_filtered.return_value = {
+        mock_get_metadata.return_value = {
             "/path/flat1.fits": {
                 NORMALIZED_HEADER_FILENAME: "/path/flat1.fits",
+                NORMALIZED_HEADER_TYPE: TYPE_MASTER_FLAT,
                 NORMALIZED_HEADER_CAMERA: "ASI2600MM",
                 NORMALIZED_HEADER_FILTER: "Ha",
+                NORMALIZED_HEADER_GAIN: "100",
             },
         }
 
@@ -250,16 +267,18 @@ class TestFindMatchingFlats:
         assert len(result) == 1
         assert result[0][NORMALIZED_HEADER_FILTER] == "Ha"
 
-    @patch("ap_common.calibration.get_filtered_metadata")
-    def test_multiple_flat_matches(self, mock_get_filtered):
+    @patch("ap_common.calibration.get_metadata")
+    def test_multiple_flat_matches(self, mock_get_metadata):
         """Test finding multiple matching flats."""
-        mock_get_filtered.return_value = {
+        mock_get_metadata.return_value = {
             "/path/flat1.fits": {
                 NORMALIZED_HEADER_FILENAME: "/path/flat1.fits",
+                NORMALIZED_HEADER_TYPE: TYPE_MASTER_FLAT,
                 NORMALIZED_HEADER_FILTER: "Ha",
             },
             "/path/flat2.fits": {
                 NORMALIZED_HEADER_FILENAME: "/path/flat2.fits",
+                NORMALIZED_HEADER_TYPE: TYPE_MASTER_FLAT,
                 NORMALIZED_HEADER_FILTER: "Ha",
             },
         }
@@ -275,10 +294,10 @@ class TestFindMatchingFlats:
 
         assert len(result) == 2
 
-    @patch("ap_common.calibration.get_filtered_metadata")
-    def test_no_flat_matches(self, mock_get_filtered):
+    @patch("ap_common.calibration.get_metadata")
+    def test_no_flat_matches(self, mock_get_metadata):
         """Test when no flats match."""
-        mock_get_filtered.return_value = {}
+        mock_get_metadata.return_value = {}
 
         reference = {NORMALIZED_HEADER_FILTER: "Ha"}
 
@@ -291,14 +310,15 @@ class TestFindMatchingFlats:
 
         assert len(result) == 0
 
-    @patch("ap_common.calibration.get_filtered_metadata")
-    def test_flat_with_date_matching(self, mock_get_filtered):
+    @patch("ap_common.calibration.get_metadata")
+    def test_flat_with_date_matching(self, mock_get_metadata):
         """Test flat matching including date field."""
         from ap_common.constants import NORMALIZED_HEADER_DATE
 
-        mock_get_filtered.return_value = {
+        mock_get_metadata.return_value = {
             "/path/flat1.fits": {
                 NORMALIZED_HEADER_FILENAME: "/path/flat1.fits",
+                NORMALIZED_HEADER_TYPE: TYPE_MASTER_FLAT,
                 NORMALIZED_HEADER_FILTER: "Ha",
                 NORMALIZED_HEADER_DATE: "2024-01-15",
             },
@@ -322,14 +342,16 @@ class TestFindMatchingFlats:
 class TestFindMatchingBias:
     """Tests for find_matching_bias function."""
 
-    @patch("ap_common.calibration.get_filtered_metadata")
-    def test_basic_bias_matching(self, mock_get_filtered):
+    @patch("ap_common.calibration.get_metadata")
+    def test_basic_bias_matching(self, mock_get_metadata):
         """Test basic bias matching."""
-        mock_get_filtered.return_value = {
+        mock_get_metadata.return_value = {
             "/path/bias1.fits": {
                 NORMALIZED_HEADER_FILENAME: "/path/bias1.fits",
+                NORMALIZED_HEADER_TYPE: TYPE_MASTER_BIAS,
                 NORMALIZED_HEADER_CAMERA: "ASI2600MM",
                 NORMALIZED_HEADER_GAIN: "100",
+                NORMALIZED_HEADER_OFFSET: "10",
             },
         }
 
@@ -353,17 +375,21 @@ class TestFindMatchingBias:
         assert len(result) == 1
         assert result[0][NORMALIZED_HEADER_GAIN] == "100"
 
-    @patch("ap_common.calibration.get_filtered_metadata")
-    def test_multiple_bias_matches(self, mock_get_filtered):
+    @patch("ap_common.calibration.get_metadata")
+    def test_multiple_bias_matches(self, mock_get_metadata):
         """Test finding multiple matching bias frames."""
-        mock_get_filtered.return_value = {
+        mock_get_metadata.return_value = {
             "/path/bias1.fits": {
                 NORMALIZED_HEADER_FILENAME: "/path/bias1.fits",
+                NORMALIZED_HEADER_TYPE: TYPE_MASTER_BIAS,
                 NORMALIZED_HEADER_CAMERA: "ASI2600MM",
+                NORMALIZED_HEADER_GAIN: "100",
             },
             "/path/bias2.fits": {
                 NORMALIZED_HEADER_FILENAME: "/path/bias2.fits",
+                NORMALIZED_HEADER_TYPE: TYPE_MASTER_BIAS,
                 NORMALIZED_HEADER_CAMERA: "ASI2600MM",
+                NORMALIZED_HEADER_GAIN: "100",
             },
         }
 
@@ -378,10 +404,10 @@ class TestFindMatchingBias:
 
         assert len(result) == 2
 
-    @patch("ap_common.calibration.get_filtered_metadata")
-    def test_no_bias_matches(self, mock_get_filtered):
+    @patch("ap_common.calibration.get_metadata")
+    def test_no_bias_matches(self, mock_get_metadata):
         """Test when no bias frames match."""
-        mock_get_filtered.return_value = {}
+        mock_get_metadata.return_value = {}
 
         reference = {NORMALIZED_HEADER_CAMERA: "ASI2600MM"}
 
@@ -395,72 +421,183 @@ class TestFindMatchingBias:
         assert len(result) == 0
 
 
-class TestIntegration:
-    """Integration tests for calibration matching."""
+class TestCacheBasedCalibrationFunctions:
+    """Tests for *_from_cache calibration functions."""
 
-    @patch("ap_common.calibration.get_filtered_metadata")
-    def test_type_override_for_darks(self, mock_get_filtered):
-        """Test that TYPE is correctly overridden to MASTER_DARK."""
-        mock_get_filtered.return_value = {}
+    def test_find_matching_darks_from_cache(self):
+        """Test find_matching_darks_from_cache filters darks from cache."""
+        # Create metadata dict
+        metadata_dict = {
+            "/path/dark1.fits": {
+                NORMALIZED_HEADER_TYPE: TYPE_MASTER_DARK,
+                NORMALIZED_HEADER_FILENAME: "/path/dark1.fits",
+                NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
+                NORMALIZED_HEADER_CAMERA: "ASI2600MM",
+                NORMALIZED_HEADER_GAIN: "100",
+            },
+            "/path/dark2.fits": {
+                NORMALIZED_HEADER_TYPE: TYPE_MASTER_DARK,
+                NORMALIZED_HEADER_FILENAME: "/path/dark2.fits",
+                NORMALIZED_HEADER_EXPOSURESECONDS: "120.0",
+                NORMALIZED_HEADER_CAMERA: "ASI2600MM",
+                NORMALIZED_HEADER_GAIN: "100",
+            },
+        }
 
         reference = {
-            NORMALIZED_HEADER_TYPE: TYPE_MASTER_DARK,  # This should be overridden
-            NORMALIZED_HEADER_CAMERA: "ASI2600MM",
             NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
+            NORMALIZED_HEADER_CAMERA: "ASI2600MM",
+            NORMALIZED_HEADER_GAIN: "100",
         }
 
-        find_matching_darks(
-            "/library",
-            reference,
-            match_fields=[NORMALIZED_HEADER_CAMERA],
-            printStatus=False,
+        # Call with cache
+        result = find_matching_darks_from_cache(
+            metadata_dict=metadata_dict,
+            reference=reference,
+            match_fields=[NORMALIZED_HEADER_CAMERA, NORMALIZED_HEADER_GAIN],
+            allow_shorter_exposure=False,
         )
 
-        # Check that build_normalized_filters was called and TYPE was set correctly
-        call_args = mock_get_filtered.call_args
-        filters = call_args[1]["filters"]
-        assert filters[NORMALIZED_HEADER_TYPE] == TYPE_MASTER_DARK
+        # Should find exact exposure match
+        assert len(result) == 1
+        assert result[0][NORMALIZED_HEADER_FILENAME] == "/path/dark1.fits"
 
-    @patch("ap_common.calibration.get_filtered_metadata")
-    def test_type_override_for_flats(self, mock_get_filtered):
-        """Test that TYPE is correctly overridden to MASTER_FLAT."""
-        mock_get_filtered.return_value = {}
+    def test_find_matching_flats_from_cache(self):
+        """Test find_matching_flats_from_cache filters flats from cache."""
+        # Create metadata dict
+        metadata_dict = {
+            "/path/flat1.fits": {
+                NORMALIZED_HEADER_TYPE: TYPE_MASTER_FLAT,
+                NORMALIZED_HEADER_FILENAME: "/path/flat1.fits",
+                NORMALIZED_HEADER_FILTER: "Ha",
+                NORMALIZED_HEADER_CAMERA: "ASI2600MM",
+            },
+            "/path/flat2.fits": {
+                NORMALIZED_HEADER_TYPE: TYPE_MASTER_FLAT,
+                NORMALIZED_HEADER_FILENAME: "/path/flat2.fits",
+                NORMALIZED_HEADER_FILTER: "OIII",
+                NORMALIZED_HEADER_CAMERA: "ASI2600MM",
+            },
+        }
 
         reference = {
-            NORMALIZED_HEADER_TYPE: "LIGHT",  # This should be overridden
             NORMALIZED_HEADER_FILTER: "Ha",
-        }
-
-        find_matching_flats(
-            "/library",
-            reference,
-            match_fields=[NORMALIZED_HEADER_FILTER],
-            printStatus=False,
-        )
-
-        # Check that TYPE was set correctly
-        call_args = mock_get_filtered.call_args
-        filters = call_args[1]["filters"]
-        assert filters[NORMALIZED_HEADER_TYPE] == TYPE_MASTER_FLAT
-
-    @patch("ap_common.calibration.get_filtered_metadata")
-    def test_type_override_for_bias(self, mock_get_filtered):
-        """Test that TYPE is correctly overridden to MASTER_BIAS."""
-        mock_get_filtered.return_value = {}
-
-        reference = {
-            NORMALIZED_HEADER_TYPE: "LIGHT",  # This should be overridden
             NORMALIZED_HEADER_CAMERA: "ASI2600MM",
         }
 
-        find_matching_bias(
-            "/library",
-            reference,
-            match_fields=[NORMALIZED_HEADER_CAMERA],
-            printStatus=False,
+        # Call with cache
+        result = find_matching_flats_from_cache(
+            metadata_dict=metadata_dict,
+            reference=reference,
+            match_fields=[NORMALIZED_HEADER_CAMERA, NORMALIZED_HEADER_FILTER],
         )
 
-        # Check that TYPE was set correctly
-        call_args = mock_get_filtered.call_args
-        filters = call_args[1]["filters"]
-        assert filters[NORMALIZED_HEADER_TYPE] == TYPE_MASTER_BIAS
+        # Should find Ha flat
+        assert len(result) == 1
+        assert result[0][NORMALIZED_HEADER_FILENAME] == "/path/flat1.fits"
+
+    def test_find_matching_bias_from_cache(self):
+        """Test find_matching_bias_from_cache filters bias from cache."""
+        # Create metadata dict
+        metadata_dict = {
+            "/path/bias1.fits": {
+                NORMALIZED_HEADER_TYPE: TYPE_MASTER_BIAS,
+                NORMALIZED_HEADER_FILENAME: "/path/bias1.fits",
+                NORMALIZED_HEADER_CAMERA: "ASI2600MM",
+                NORMALIZED_HEADER_GAIN: "100",
+            },
+            "/path/bias2.fits": {
+                NORMALIZED_HEADER_TYPE: TYPE_MASTER_BIAS,
+                NORMALIZED_HEADER_FILENAME: "/path/bias2.fits",
+                NORMALIZED_HEADER_CAMERA: "ASI2600MM",
+                NORMALIZED_HEADER_GAIN: "200",
+            },
+        }
+
+        reference = {
+            NORMALIZED_HEADER_CAMERA: "ASI2600MM",
+            NORMALIZED_HEADER_GAIN: "100",
+        }
+
+        # Call with cache
+        result = find_matching_bias_from_cache(
+            metadata_dict=metadata_dict,
+            reference=reference,
+            match_fields=[NORMALIZED_HEADER_CAMERA, NORMALIZED_HEADER_GAIN],
+        )
+
+        # Should find gain 100 bias
+        assert len(result) == 1
+        assert result[0][NORMALIZED_HEADER_FILENAME] == "/path/bias1.fits"
+
+    def test_cache_functions_dont_do_disk_io(self):
+        """Test that *_from_cache functions don't do disk I/O."""
+        # Cache functions operate purely in memory
+        # They should work without any file system access
+        metadata_dict = {
+            "/path/dark1.fits": {
+                NORMALIZED_HEADER_TYPE: TYPE_MASTER_DARK,
+                NORMALIZED_HEADER_FILENAME: "/path/dark1.fits",
+                NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
+                NORMALIZED_HEADER_CAMERA: "ASI2600MM",
+            },
+        }
+
+        reference = {
+            NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
+            NORMALIZED_HEADER_CAMERA: "ASI2600MM",
+        }
+
+        # Should work without disk access
+        result = find_matching_darks_from_cache(
+            metadata_dict=metadata_dict,
+            reference=reference,
+            match_fields=[NORMALIZED_HEADER_CAMERA],
+        )
+
+        # Should return results from cache
+        assert len(result) == 1
+        assert result[0][NORMALIZED_HEADER_FILENAME] == "/path/dark1.fits"
+
+    def test_cache_functions_filter_by_criteria(self):
+        """Test *_from_cache functions filter by match criteria correctly."""
+        # Create metadata dict with multiple darks
+        metadata_dict = {
+            "/path/dark1.fits": {
+                NORMALIZED_HEADER_TYPE: TYPE_MASTER_DARK,
+                NORMALIZED_HEADER_FILENAME: "/path/dark1.fits",
+                NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
+                NORMALIZED_HEADER_CAMERA: "ASI2600MM",
+                NORMALIZED_HEADER_GAIN: "100",
+            },
+            "/path/dark2.fits": {
+                NORMALIZED_HEADER_TYPE: TYPE_MASTER_DARK,
+                NORMALIZED_HEADER_FILENAME: "/path/dark2.fits",
+                NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
+                NORMALIZED_HEADER_CAMERA: "ASI2600MM",
+                NORMALIZED_HEADER_GAIN: "200",  # Different gain
+            },
+            "/path/flat1.fits": {
+                NORMALIZED_HEADER_TYPE: TYPE_MASTER_FLAT,  # Wrong type
+                NORMALIZED_HEADER_FILENAME: "/path/flat1.fits",
+                NORMALIZED_HEADER_CAMERA: "ASI2600MM",
+                NORMALIZED_HEADER_GAIN: "100",
+            },
+        }
+
+        reference = {
+            NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
+            NORMALIZED_HEADER_CAMERA: "ASI2600MM",
+            NORMALIZED_HEADER_GAIN: "100",
+        }
+
+        # Call with cache
+        result = find_matching_darks_from_cache(
+            metadata_dict=metadata_dict,
+            reference=reference,
+            match_fields=[NORMALIZED_HEADER_CAMERA, NORMALIZED_HEADER_GAIN],
+        )
+
+        # Should find only dark1 (matches camera+gain, not dark2 or flat1)
+        assert len(result) == 1
+        assert result[0][NORMALIZED_HEADER_FILENAME] == "/path/dark1.fits"


### PR DESCRIPTION
- Add cache-based calibration matching functions to avoid redundant disk I/O
- Refactor existing functions to delegate to cache-based implementations
- Add DEFAULT_IMAGE_PATTERNS constant for all supported image types
- Update tests to mock get_metadata and validate cache-based functions

Assisted-by: Claude Code (claude-sonnet-4-5-20250929)