### PR TITLE
Fix numeric string comparison in calibration frame matching

### DIFF
--- a/ap_common/calibration.py
+++ b/ap_common/calibration.py
@@ -14,6 +14,7 @@ import logging
 from ap_common.metadata import (
     get_metadata,
     build_normalized_filters,
+    filter_metadata,
 )
 from ap_common.constants import (
     TYPE_MASTER_DARK,
@@ -288,12 +289,8 @@ def find_matching_darks_from_cache(
     logger.debug(f"Searching for darks in cache with criteria: {filter_criteria}")
     logger.debug(f"Target exposure: {light_exposure}s")
 
-    # Filter from provided metadata dict
-    darks = {}
-    for filename, metadata in metadata_dict.items():
-        # Check if metadata matches all filter criteria
-        if all(metadata.get(k) == v for k, v in filter_criteria.items()):
-            darks[filename] = metadata
+    # Filter from provided metadata dict using numeric-aware comparison
+    darks = filter_metadata(metadata_dict, filter_criteria)
 
     logger.debug(f"Found {len(darks)} darks matching criteria in cache")
 
@@ -365,12 +362,8 @@ def find_matching_flats_from_cache(
 
     logger.debug(f"Searching for flats in cache with criteria: {filter_criteria}")
 
-    # Filter from provided metadata dict
-    flats = {}
-    for filename, metadata in metadata_dict.items():
-        # Check if metadata matches all filter criteria
-        if all(metadata.get(k) == v for k, v in filter_criteria.items()):
-            flats[filename] = metadata
+    # Filter from provided metadata dict using numeric-aware comparison
+    flats = filter_metadata(metadata_dict, filter_criteria)
 
     logger.debug(f"Found {len(flats)} matching flats in cache")
 
@@ -420,12 +413,8 @@ def find_matching_bias_from_cache(
 
     logger.debug(f"Searching for bias in cache with criteria: {filter_criteria}")
 
-    # Filter from provided metadata dict
-    bias = {}
-    for filename, metadata in metadata_dict.items():
-        # Check if metadata matches all filter criteria
-        if all(metadata.get(k) == v for k, v in filter_criteria.items()):
-            bias[filename] = metadata
+    # Filter from provided metadata dict using numeric-aware comparison
+    bias = filter_metadata(metadata_dict, filter_criteria)
 
     logger.debug(f"Found {len(bias)} matching bias frames in cache")
 

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -598,3 +598,110 @@ class TestCacheBasedCalibrationFunctions:
         # Should find only dark1 (matches camera+gain, not dark2 or flat1)
         assert len(result) == 1
         assert result[0][NORMALIZED_HEADER_FILENAME] == "/path/dark1.fits"
+
+    def test_numeric_string_comparison_in_flats_from_cache(self):
+        """Test that flats match with different decimal representations.
+
+        Regression test for bug where focal length "2032" doesn't match "2032.0".
+        The *_from_cache functions should use numeric-aware comparison like
+        filter_metadata() does, not simple string comparison.
+        """
+        from ap_common.constants import NORMALIZED_HEADER_FOCALLEN
+
+        # Flat has focal length without decimal
+        metadata_dict = {
+            "/path/flat1.fits": {
+                NORMALIZED_HEADER_TYPE: TYPE_MASTER_FLAT,
+                NORMALIZED_HEADER_FILENAME: "/path/flat1.fits",
+                NORMALIZED_HEADER_FILTER: "Ha",
+                NORMALIZED_HEADER_CAMERA: "ASI2600MM",
+                NORMALIZED_HEADER_FOCALLEN: "2032",  # No decimal
+            },
+        }
+
+        # Reference has focal length with decimal
+        reference = {
+            NORMALIZED_HEADER_FILTER: "Ha",
+            NORMALIZED_HEADER_CAMERA: "ASI2600MM",
+            NORMALIZED_HEADER_FOCALLEN: "2032.0",  # With decimal
+        }
+
+        result = find_matching_flats_from_cache(
+            metadata_dict=metadata_dict,
+            reference=reference,
+            match_fields=[
+                NORMALIZED_HEADER_CAMERA,
+                NORMALIZED_HEADER_FILTER,
+                NORMALIZED_HEADER_FOCALLEN,
+            ],
+        )
+
+        # Should match via numeric comparison
+        assert len(result) == 1
+        assert result[0][NORMALIZED_HEADER_FILENAME] == "/path/flat1.fits"
+
+    def test_numeric_string_comparison_in_darks_from_cache(self):
+        """Test that darks match with different decimal representations."""
+        # Dark has gain without decimal
+        metadata_dict = {
+            "/path/dark1.fits": {
+                NORMALIZED_HEADER_TYPE: TYPE_MASTER_DARK,
+                NORMALIZED_HEADER_FILENAME: "/path/dark1.fits",
+                NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
+                NORMALIZED_HEADER_CAMERA: "ASI2600MM",
+                NORMALIZED_HEADER_GAIN: "100",  # Integer string
+            },
+        }
+
+        # Reference has gain with decimal
+        reference = {
+            NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
+            NORMALIZED_HEADER_CAMERA: "ASI2600MM",
+            NORMALIZED_HEADER_GAIN: "100.0",  # Float string
+        }
+
+        result = find_matching_darks_from_cache(
+            metadata_dict=metadata_dict,
+            reference=reference,
+            match_fields=[NORMALIZED_HEADER_CAMERA, NORMALIZED_HEADER_GAIN],
+        )
+
+        # Should match via numeric comparison
+        assert len(result) == 1
+        assert result[0][NORMALIZED_HEADER_FILENAME] == "/path/dark1.fits"
+
+    def test_numeric_string_comparison_in_bias_from_cache(self):
+        """Test that bias frames match with different decimal representations."""
+        from ap_common.constants import NORMALIZED_HEADER_SETTEMP
+
+        # Bias has settemp as integer string
+        metadata_dict = {
+            "/path/bias1.fits": {
+                NORMALIZED_HEADER_TYPE: TYPE_MASTER_BIAS,
+                NORMALIZED_HEADER_FILENAME: "/path/bias1.fits",
+                NORMALIZED_HEADER_CAMERA: "ASI2600MM",
+                NORMALIZED_HEADER_GAIN: "100",
+                NORMALIZED_HEADER_SETTEMP: "-10",  # Integer string
+            },
+        }
+
+        # Reference has settemp with decimal
+        reference = {
+            NORMALIZED_HEADER_CAMERA: "ASI2600MM",
+            NORMALIZED_HEADER_GAIN: "100",
+            NORMALIZED_HEADER_SETTEMP: "-10.0",  # Float string
+        }
+
+        result = find_matching_bias_from_cache(
+            metadata_dict=metadata_dict,
+            reference=reference,
+            match_fields=[
+                NORMALIZED_HEADER_CAMERA,
+                NORMALIZED_HEADER_GAIN,
+                NORMALIZED_HEADER_SETTEMP,
+            ],
+        )
+
+        # Should match via numeric comparison
+        assert len(result) == 1
+        assert result[0][NORMALIZED_HEADER_FILENAME] == "/path/bias1.fits"


### PR DESCRIPTION
- Replace manual string comparison with filter_metadata in *_from_cache functions
- Calibration frames now match when numeric metadata has different decimal representations
- Fixes focal length "2032" vs "2032.0" mismatch bug

Assisted-by: Claude Code (Claude Sonnet 4.5)